### PR TITLE
Native diff

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/mitchellh/go-homedir v0.0.0-20161203194507-b8bc1bf76747 // indirect
 	github.com/pelletier/go-buffruneio v0.2.0 // indirect
 	github.com/pkg/errors v0.8.0 // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0
 	github.com/sergi/go-diff v1.0.0 // indirect
 	github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d // indirect
 	github.com/smartystreets/goconvey v0.0.0-20181108003508-044398e4856c // indirect

--- a/src/core/application.go
+++ b/src/core/application.go
@@ -107,15 +107,7 @@ func (a *Application) StandardRun() {
 		}
 	}
 	// Collect everything
-	changedFiles, diffs := worker.RunCollectors()
-	// Email diffs if changes are detected and email is enabled
-	if len(changedFiles) > 0 && a.config.EmailEnabled {
-		err := utils.GitSendEmail(a.config, diffs, changedFiles)
-		if err != nil {
-			// Log the error, but carry on.
-			log.Printf("WARNING: GIT notification email error: %v\n", err)
-		}
-	}
+	worker.RunCollectors()
 	// And check for any necessary commits.
 	err := utils.GitOps(a.config)
 	if err != nil {

--- a/src/core/application.go
+++ b/src/core/application.go
@@ -107,8 +107,15 @@ func (a *Application) StandardRun() {
 		}
 	}
 	// Collect everything
-	worker.RunCollectors()
-
+	changedFiles, diffs := worker.RunCollectors()
+	// Email diffs if changes are detected and email is enabled
+	if len(changedFiles) > 0 && a.config.EmailEnabled {
+		err := utils.GitSendEmail(a.config, diffs, changedFiles)
+		if err != nil {
+			// Log the error, but carry on.
+			log.Printf("WARNING: GIT notification email error: %v\n", err)
+		}
+	}
 	// And check for any necessary commits.
 	err := utils.GitOps(a.config)
 	if err != nil {

--- a/src/utils/git/commit.go
+++ b/src/utils/git/commit.go
@@ -8,10 +8,8 @@ import (
 )
 
 // Commit will add and commit changes
-func Commit(path string, status git.Status, worktree git.Worktree) ([]string, []string, error) {
+func Commit(path string, status git.Status, worktree git.Worktree) error {
 	// Iterate over changed files to determine what is changed
-	var changes []string
-	var changedFiles []string
 	for file, status := range status {
 
 		// TODO: Maybe a cleaner way to do this?
@@ -29,15 +27,6 @@ func Commit(path string, status git.Status, worktree git.Worktree) ([]string, []
 			log.Printf("Unhandled git status for file %s\n", file)
 
 		}
-		// Tack on files
-		changedFiles = append(changedFiles, file)
-
-		// Tack on diffs.
-		diff, err := GitDiff(path, file)
-		if err != nil {
-			return nil, nil, err
-		}
-		changes = append(changes, diff)
 	}
 
 	// Do the commit
@@ -51,8 +40,8 @@ func Commit(path string, status git.Status, worktree git.Worktree) ([]string, []
 			},
 		})
 	if err != nil {
-		return nil, nil, err
+		return err
 	}
 	log.Printf("Contra Git Commit: %s", commit)
-	return changes, changedFiles, err
+	return nil
 }

--- a/src/utils/git/commit.go
+++ b/src/utils/git/commit.go
@@ -8,7 +8,7 @@ import (
 )
 
 // Commit will add and commit changes
-func Commit(path string, status git.Status, worktree git.Worktree) error {
+func Commit(status git.Status, worktree git.Worktree) error {
 	// Iterate over changed files to determine what is changed
 	for file, status := range status {
 

--- a/src/utils/git/diff.go
+++ b/src/utils/git/diff.go
@@ -1,26 +1,27 @@
 package utils
 
 import (
-	"github.com/aja-video/contra/src/configuration"
 	"github.com/pmezard/go-difflib/difflib"
 	"io/ioutil"
 	"log"
 )
 
 // GitDiff returns a diff of the existing config and the collector output
-func GitDiff(config configuration.Config, filename string, output string) (string, error) {
-	qualifiedFile := config.Workspace + `/` + filename
+func GitDiff(workspace, filename string, output string) (string, error) {
+	qualifiedFile := workspace + `/` + filename
 	oldFile, err := ioutil.ReadFile(qualifiedFile)
 	if err != nil {
 		log.Printf("unable to open device configuration %s - assuming new config\n", qualifiedFile)
 		oldFile = nil
 	}
 	diff := difflib.UnifiedDiff{
-		A:        difflib.SplitLines(string(oldFile)),
-		B:        difflib.SplitLines(output),
+		A: difflib.SplitLines(string(oldFile)),
+		B: difflib.SplitLines(output),
+		// diff source name
 		FromFile: filename,
-		ToFile:   "Collector Output",
-		Context:  3,
+		// diff destination name
+		ToFile:  "Collector Output",
+		Context: 3,
 	}
 	changes, err := difflib.GetUnifiedDiffString(diff)
 	return changes, err

--- a/src/utils/git/diff.go
+++ b/src/utils/git/diff.go
@@ -1,6 +1,9 @@
 package utils
 
 import (
+	"github.com/pmezard/go-difflib/difflib"
+	"io/ioutil"
+	"log"
 	"os/exec"
 )
 
@@ -25,6 +28,22 @@ func gitDiffExec(path, filename string) (string, error) {
 	return string(diff), err
 }
 
-func gitDiffNative() {
-	// Someday...
+// gitDiffNative returns a diff of the existing config and the collector output
+func gitDiffNative(path string, filename string, output string) string {
+	qualifiedFile := path + `/` + filename
+	oldFile, err := ioutil.ReadFile(qualifiedFile)
+	if err != nil {
+		log.Fatalf("Unable to open file %s\n", qualifiedFile)
+	}
+	diff := difflib.UnifiedDiff{
+		A:        difflib.SplitLines(string(oldFile)),
+		B:        difflib.SplitLines(output),
+		FromFile: filename,
+		ToFile:   "Collector Output",
+		Context:  3,
+	}
+
+	changes, _ := difflib.GetUnifiedDiffString(diff)
+
+	return changes
 }

--- a/src/utils/git/diff.go
+++ b/src/utils/git/diff.go
@@ -1,39 +1,19 @@
 package utils
 
 import (
+	"github.com/aja-video/contra/src/configuration"
 	"github.com/pmezard/go-difflib/difflib"
 	"io/ioutil"
 	"log"
-	"os/exec"
 )
 
-// GitDiff returns a diff.
-func GitDiff(path, filename string) (string, error) {
-	// Explicitly reminding ourselves that we're using exec.
-	return gitDiffExec(path, filename)
-}
-
-// gitDiffExec uses os/exec to pull a git diff.
-func gitDiffExec(path, filename string) (string, error) {
-	// Prep the command.
-	cmd := exec.Command("git", "diff", "-U4", "HEAD", filename)
-	// Switch to the workspace folder.
-	cmd.Dir = path
-	// Run!
-	diff, err := cmd.Output()
-	if err != nil {
-		return "", err
-	}
-
-	return string(diff), err
-}
-
-// gitDiffNative returns a diff of the existing config and the collector output
-func gitDiffNative(path string, filename string, output string) string {
-	qualifiedFile := path + `/` + filename
+// GitDiff returns a diff of the existing config and the collector output
+func GitDiff(config configuration.Config, filename string, output string) (string, error) {
+	qualifiedFile := config.Workspace + `/` + filename
 	oldFile, err := ioutil.ReadFile(qualifiedFile)
 	if err != nil {
-		log.Fatalf("Unable to open file %s\n", qualifiedFile)
+		log.Printf("unable to open device configuration %s - assuming new config\n", qualifiedFile)
+		oldFile = nil
 	}
 	diff := difflib.UnifiedDiff{
 		A:        difflib.SplitLines(string(oldFile)),
@@ -42,8 +22,6 @@ func gitDiffNative(path string, filename string, output string) string {
 		ToFile:   "Collector Output",
 		Context:  3,
 	}
-
-	changes, _ := difflib.GetUnifiedDiffString(diff)
-
-	return changes
+	changes, err := difflib.GetUnifiedDiffString(diff)
+	return changes, err
 }

--- a/src/utils/git/diff.go
+++ b/src/utils/git/diff.go
@@ -11,7 +11,7 @@ func GitDiff(workspace, filename string, output string) (string, error) {
 	qualifiedFile := workspace + `/` + filename
 	oldFile, err := ioutil.ReadFile(qualifiedFile)
 	if err != nil {
-		log.Printf("unable to open device configuration %s - assuming new config\n", qualifiedFile)
+		log.Printf("unable to open an existing device config file %s - assuming new device\n", qualifiedFile)
 		oldFile = nil
 	}
 	diff := difflib.UnifiedDiff{

--- a/src/utils/git/git.go
+++ b/src/utils/git/git.go
@@ -41,17 +41,11 @@ func GitOps(c *configuration.Config) error {
 	// Status will evaluate to true if something has changed
 	if changes {
 		// Commit if changes detected
-		changesOut, changedFiles, err := Commit(repo.Path, status, *worktree)
+		err := Commit(repo.Path, status, *worktree)
 		if err != nil {
 			return err
 		}
 		log.Println("GIT changes committed.")
-
-		err = gitSendEmail(c, changesOut, changedFiles)
-		if err != nil {
-			// Log the error, but carry on.
-			log.Printf("WARNING: GIT notification email error: %v\n", err)
-		}
 
 		// push to remote if configured
 		if c.GitPush {
@@ -71,8 +65,8 @@ func GitOps(c *configuration.Config) error {
 	return err
 }
 
-//gitSendEmail sends git related email notifications
-func gitSendEmail(c *configuration.Config, changes, changedFiles []string) error {
+// GitSendEmail sends git related email notifications
+func GitSendEmail(c *configuration.Config, changes, changedFiles []string) error {
 
 	// Bail out if email is disabled
 	if !c.EmailEnabled {

--- a/src/utils/git/git.go
+++ b/src/utils/git/git.go
@@ -41,7 +41,7 @@ func GitOps(c *configuration.Config) error {
 	// Status will evaluate to true if something has changed
 	if changes {
 		// Commit if changes detected
-		err := Commit(repo.Path, status, *worktree)
+		err := Commit(status, *worktree)
 		if err != nil {
 			return err
 		}
@@ -66,7 +66,7 @@ func GitOps(c *configuration.Config) error {
 }
 
 // GitSendEmail sends git related email notifications
-func GitSendEmail(c *configuration.Config, changes, changedFiles []string) error {
+func GitSendEmail(c *configuration.Config, diffs []string) error {
 
 	// Bail out if email is disabled
 	if !c.EmailEnabled {
@@ -75,9 +75,7 @@ func GitSendEmail(c *configuration.Config, changes, changedFiles []string) error
 	}
 
 	// Convert slice of changes to a comma separated string
-	changesString := strings.Join(changes, "\n")
-
-	log.Printf("%s changed, sending email\n", strings.Join(changedFiles, ","))
+	changesString := strings.Join(diffs, "\n")
 
 	// Send email with changes
 	err := utils.SendEmail(c, c.EmailSubject, changesString)

--- a/src/utils/writefile.go
+++ b/src/utils/writefile.go
@@ -1,7 +1,6 @@
 package utils
 
 import (
-	"github.com/aja-video/contra/src/configuration"
 	"io/ioutil"
 	"log"
 	"os"
@@ -9,11 +8,11 @@ import (
 )
 
 // WriteFile saves output to a file
-func WriteFile(c configuration.Config, config string, name string) error {
+func WriteFile(workspace, config, name string) error {
 	// Create file inside workspace folder
-	err := workspaceExists(c)
+	err := workspaceExists(workspace)
 	if err == nil {
-		f, err := os.Create(c.Workspace + "/" + name)
+		f, err := os.Create(workspace + "/" + name)
 		if err != nil {
 			log.Printf("Unable to create config file %s\n", name)
 			return err
@@ -28,14 +27,14 @@ func WriteFile(c configuration.Config, config string, name string) error {
 }
 
 // workspaceExists checks for or creates the workspace directory
-func workspaceExists(c configuration.Config) error {
+func workspaceExists(workspace string) error {
 	// Check if the workspace is a directory
-	if ws, err := os.Stat(c.Workspace); err == nil && ws.IsDir() {
+	if ws, err := os.Stat(workspace); err == nil && ws.IsDir() {
 		return nil
 	}
 
 	// Create directory if it isn't there
-	err := os.Mkdir(c.Workspace, os.ModePerm)
+	err := os.Mkdir(workspace, os.ModePerm)
 
 	return err
 }


### PR DESCRIPTION
Do the diff without exec (should remove git package dependency).
The go-git diff functions are a wrapper around https://github.com/sergi/go-diff which is basically worthless for this purpose.
Pulled in https://github.com/pmezard/go-difflib which made this quite simple.
Required an overhaul of GitOps() - diffs now run before the file is written and committed.
Closes #7 