### PR TITLE
Netgear

### DIFF
--- a/src/collectors/collector_registry.go
+++ b/src/collectors/collector_registry.go
@@ -10,6 +10,7 @@ var deviceMap = map[string]interface{}{
 	"edgeswitch": devices.DeviceEdgeSwitch{},
 	"fortinet":   devices.DeviceFortinet{},
 	"mikrotik":   devices.DeviceMikrotik{},
+	"netgear":    devices.DeviceNetgear{},
 	"pfsense":    devices.DevicePfsense{},
 	"procurve":   devices.DeviceProcurve{},
 	"vyatta":     devices.DeviceVyatta{},

--- a/src/devices/arista.go
+++ b/src/devices/arista.go
@@ -1,6 +1,7 @@
 package devices
 
 import (
+	"fmt"
 	"github.com/aja-video/contra/src/configuration"
 	"github.com/aja-video/contra/src/utils"
 	"github.com/google/goexpect"
@@ -30,7 +31,10 @@ func (p *DeviceArista) BuildBatcher() ([]expect.Batcher, error) {
 // ParseResult for Arista
 func (p *DeviceArista) ParseResult(result string) (string, error) {
 
-	matcher := regexp.MustCompile(`![\s\S]*end`)
+	matcher := regexp.MustCompile(`(?ms)!.*?^end`)
 	match := matcher.FindStringSubmatch(result)
+	if len(match) == 0 {
+		return "", fmt.Errorf("Arista configuration match not found")
+	}
 	return match[0], nil
 }

--- a/src/devices/arista.go
+++ b/src/devices/arista.go
@@ -22,7 +22,6 @@ func (p *DeviceArista) BuildBatcher() ([]expect.Batcher, error) {
 	return utils.SimpleBatcher([][]string{
 		{".*>", "terminal length 0"},
 		{".*>", "enable"},
-		{"Password:", p.UnlockPass},
 		{".*#", "show run"},
 		{"end"},
 	})

--- a/src/devices/arista_test.go
+++ b/src/devices/arista_test.go
@@ -1,0 +1,48 @@
+package devices
+
+import (
+	"testing"
+)
+
+func TestParseResult(t *testing.T) {
+	d := &DeviceArista{}
+
+	testcases := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "Matching input",
+			input:    "!this is a test \nend",
+			expected: "!this is a test \nend",
+		},
+		{
+			name:     "No endings",
+			input:    "!this is a test",
+			expected: "",
+		},
+		{
+			name:     "Empty string",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "Complex example",
+			input:    "!123\n123 end \n!456\nend",
+			expected: "!123\n123 end \n!456\nend",
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			output, err := d.ParseResult(tc.input)
+			if err != nil && err.Error() != "Arista configuration match not found" {
+				t.Errorf("Got unexpected error: %v", err)
+			}
+			if output != tc.expected {
+				t.Errorf("Expected %s, but got %s", tc.expected, output)
+			}
+		})
+	}
+}

--- a/src/devices/netgear.go
+++ b/src/devices/netgear.go
@@ -1,0 +1,39 @@
+package devices
+
+import (
+	"fmt"
+	"github.com/aja-video/contra/src/configuration"
+	"github.com/aja-video/contra/src/utils"
+	expect "github.com/google/goexpect"
+	"regexp"
+)
+
+// DeviceNetgear logic container for device.
+type DeviceNetgear struct {
+	configuration.DeviceConfig
+}
+
+// SetDeviceConfig since it is unclear how to assign DeviceConfig via reflect.New
+func (p *DeviceNetgear) SetDeviceConfig(deviceConfig configuration.DeviceConfig) {
+	p.DeviceConfig = deviceConfig
+}
+
+// BuildBatcher for Netgear
+func (p *DeviceNetgear) BuildBatcher() ([]expect.Batcher, error) {
+	return utils.SimpleBatcher([][]string{
+		{".*#", "no pager"},
+		{".*#", "show run"},
+		{".*#"},
+	})
+}
+
+// ParseResult for Netgear
+func (p *DeviceNetgear) ParseResult(result string) (string, error) {
+
+	matcher := regexp.MustCompile(`(?ms)configure.*?#$`)
+	match := matcher.FindStringSubmatch(result)
+	if len(match) == 0 {
+		return "", fmt.Errorf("netgear configuration match not found")
+	}
+	return match[0], nil
+}

--- a/src/devices/netgear_test.go
+++ b/src/devices/netgear_test.go
@@ -1,0 +1,48 @@
+package devices
+
+import (
+	"testing"
+)
+
+func TestParseResultNetgear(t *testing.T) {
+	d := &DeviceNetgear{}
+
+	testcases := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "Matching input",
+			input:    "!this\nconfigure is a test \n\n(M4500) #",
+			expected: "configure is a test \n\n(M4500) #",
+		},
+		{
+			name:     "No endings",
+			input:    "!this\nconfigure is a test",
+			expected: "",
+		},
+		{
+			name:     "Empty string",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "Complex example",
+			input:    "!123\nconfigure\n123 'hello'\n!456\n\n(system-name) #",
+			expected: "configure\n123 'hello'\n!456\n\n(system-name) #",
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			output, err := d.ParseResult(tc.input)
+			if err != nil && err.Error() != "netgear configuration match not found" {
+				t.Errorf("Got unexpected error: %v", err)
+			}
+			if output != tc.expected {
+				t.Errorf("Expected %s, but got %s", tc.expected, output)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This pull request adds support for Netgear devices and improves the robustness of configuration parsing for Arista devices. It also introduces unit tests for both device types to ensure parsing logic is correct.

**Netgear device support:**

* Added a new device implementation in `src/devices/netgear.go` with logic for batch command execution and configuration parsing.
* Registered Netgear devices in the device registry map in `src/collectors/collector_registry.go`.

**Arista device parsing improvements:**

* Updated the regular expression in `DeviceArista.ParseResult` to be more precise and added error handling for unmatched configurations in `src/devices/arista.go`.
* Removed the password batch step from `DeviceArista.BuildBatcher` for improved reliability.

**Unit tests:**

* Added unit tests for Arista configuration parsing in `src/devices/arista_test.go`.
* Added unit tests for Netgear configuration parsing in `src/devices/netgear_test.go`.