### PR TITLE
feat(collectors): add backoff to device failure notifications

### DIFF
--- a/contra.example.conf
+++ b/contra.example.conf
@@ -44,7 +44,12 @@
     Host           = 127.0.0.1
     Port           = 22
     Ciphers        = 3des-cbc # Comma separated list
+    # FailureWarning is the number of consecutive failed runs before the first alert. 0 disables alerts.
     FailureWarning = 0
+    # After FailureBackoffCount alerts in one failure episode, alerts are rate limited to
+    # one per FailureBackoffInterval (defaults: 5 alerts, then 24h spacing).
+    FailureBackoffCount    = 5
+    FailureBackoffInterval = 24h
 
 [the-other-cisco]
     Disabled = true

--- a/src/collectors/collector_worker.go
+++ b/src/collectors/collector_worker.go
@@ -130,10 +130,8 @@ func (cw *CollectorWorker) Run(device configuration.DeviceConfig) (string, error
 			return "", cw.collectFailure(device, err)
 		}
 
-		// Read from FailChan if it isn't empty
-		if len(device.FailChan) > 0 {
-			<-device.FailChan
-		}
+		// Successful collection - clear any recorded failure state for this device.
+		globalFailureTracker.recordSuccess(device.Name)
 		// Close ssh connection
 		err = connection.Close()
 		if err != nil {
@@ -163,20 +161,16 @@ func (cw *CollectorWorker) Run(device configuration.DeviceConfig) (string, error
 
 // collectFailure handles collector failures
 func (cw *CollectorWorker) collectFailure(d configuration.DeviceConfig, err error) error {
-	// define email notification content
-	var message []string
-	message = append(message, "Contra was unable to gather configs from",
-		d.Name, strconv.Itoa(d.FailureWarning), "times", "last error:", err.Error())
-	// Add an element to the warning queue if it isn't full
-	if len(d.FailChan) < cap(d.FailChan) {
-		d.FailChan <- true
-	} else if cap(d.FailChan) > 0 {
-		// Fire off an email if the warning queue is full and email is enabled
-		_ = utils.SendEmail(cw.RunConfig, "Contra failure warning!", strings.Join(message, " "))
-		// Empty the channel after we've reset a notification
-		for len(d.FailChan) > 0 {
-			<-d.FailChan
+	// Record the failure and decide whether it warrants an alert. The tracker applies the
+	// initial threshold and the backoff so runaway failures don't flood the inbox.
+	if globalFailureTracker.recordFailure(d.Name, d.FailureWarning, d.FailureBackoffCount, d.FailureBackoffInterval, time.Now()) {
+		message := []string{
+			"Contra was unable to gather configs from", d.Name,
+			"after", strconv.Itoa(d.FailureWarning), "consecutive failed attempts.",
+			"last error:", err.Error(),
 		}
+		// Fire off an email. Email failure is logged elsewhere and does not interrupt this process.
+		_ = utils.SendEmail(cw.RunConfig, "Contra failure warning!", strings.Join(message, " "))
 	}
 
 	// log a warning, reminder the matcher could be out of date, or incomplete.

--- a/src/collectors/failure_tracker.go
+++ b/src/collectors/failure_tracker.go
@@ -1,0 +1,90 @@
+package collectors
+
+import (
+	"sync"
+	"time"
+)
+
+// deviceFailureState tracks the failure and notification history for a single device
+// across daemon run intervals.
+type deviceFailureState struct {
+	// consecutiveFailures is the number of failed runs since the last success.
+	consecutiveFailures int
+	// notifyCount is the number of alerts sent during the current failure episode.
+	notifyCount int
+	// lastNotified is when the most recent alert was sent.
+	lastNotified time.Time
+}
+
+// failureTracker holds failure state for all devices, keyed by device name.
+type failureTracker struct {
+	mu     sync.Mutex
+	states map[string]*deviceFailureState
+}
+
+// globalFailureTracker persists device failure state for the lifetime of the process.
+// It lives at package scope on purpose: CollectorWorker is recreated on every run, and
+// the config that carries per-device settings is rebuilt on every daemon interval by
+// ReloadConfig. State kept on the (reloaded) DeviceConfig would reset each interval, so
+// the failure counter has to live somewhere that outlives both.
+var globalFailureTracker = &failureTracker{
+	states: make(map[string]*deviceFailureState),
+}
+
+// recordSuccess clears any failure state for the named device, ending its failure episode.
+func (t *failureTracker) recordSuccess(name string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	delete(t.states, name)
+}
+
+// recordFailure registers a failed collection for the device and reports whether an alert
+// should be sent for this failure.
+//
+// warning is the number of consecutive failed runs before the first alert (0 disables
+// alerts entirely). Until backoffCount alerts have been sent in the current episode, an
+// alert fires on every warning failed runs. After that, backoff engages and further
+// alerts are rate limited to at most one per backoffInterval. now is supplied by the
+// caller so the clock can be controlled in tests.
+func (t *failureTracker) recordFailure(name string, warning, backoffCount int, backoffInterval time.Duration, now time.Time) bool {
+	// A zero (or negative) warning threshold disables alerts for this device.
+	if warning <= 0 {
+		return false
+	}
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	state, ok := t.states[name]
+	if !ok {
+		state = &deviceFailureState{}
+		t.states[name] = state
+	}
+	state.consecutiveFailures++
+
+	// Below the initial threshold, stay quiet.
+	if state.consecutiveFailures < warning {
+		return false
+	}
+
+	notify := false
+	if state.notifyCount < backoffCount {
+		// Before backoff: alert once every `warning` consecutive failed runs. Each run
+		// increments consecutiveFailures by exactly one, so a modulo on the overage gives
+		// a steady count-based cadence (first alert lands exactly at `warning`).
+		if (state.consecutiveFailures-warning)%warning == 0 {
+			notify = true
+		}
+	} else {
+		// Backoff engaged: alert at most once per interval.
+		if now.Sub(state.lastNotified) >= backoffInterval {
+			notify = true
+		}
+	}
+
+	if notify {
+		state.notifyCount++
+		state.lastNotified = now
+	}
+	return notify
+}

--- a/src/collectors/failure_tracker_test.go
+++ b/src/collectors/failure_tracker_test.go
@@ -1,0 +1,104 @@
+package collectors
+
+import (
+	"testing"
+	"time"
+)
+
+// newTestTracker returns an isolated tracker so tests don't share the package global.
+func newTestTracker() *failureTracker {
+	return &failureTracker{states: make(map[string]*deviceFailureState)}
+}
+
+// TestRecordFailureDisabled verifies a zero warning threshold never alerts.
+func TestRecordFailureDisabled(t *testing.T) {
+	tr := newTestTracker()
+	now := time.Unix(0, 0)
+	for i := 0; i < 10; i++ {
+		if tr.recordFailure("dev", 0, 5, 24*time.Hour, now) {
+			t.Fatalf("expected no alert with warning=0, got one on failure %d", i+1)
+		}
+	}
+}
+
+// TestRecordFailureInitialThreshold verifies the first alert lands exactly at `warning`
+// failures and then repeats every `warning` failures before backoff.
+func TestRecordFailureInitialThreshold(t *testing.T) {
+	tr := newTestTracker()
+	now := time.Unix(0, 0)
+	warning := 5
+	var alerts []int
+	for i := 1; i <= 15; i++ {
+		if tr.recordFailure("dev", warning, 5, 24*time.Hour, now) {
+			alerts = append(alerts, i)
+		}
+	}
+	want := []int{5, 10, 15}
+	if len(alerts) != len(want) {
+		t.Fatalf("expected alerts at %v, got %v", want, alerts)
+	}
+	for i := range want {
+		if alerts[i] != want[i] {
+			t.Fatalf("expected alerts at %v, got %v", want, alerts)
+		}
+	}
+}
+
+// TestRecordFailureBackoff verifies that once backoffCount alerts have fired, further
+// alerts are rate limited to one per backoffInterval regardless of failure cadence.
+func TestRecordFailureBackoff(t *testing.T) {
+	tr := newTestTracker()
+	warning := 1        // alert on every failure until backoff
+	backoffCount := 3   // engage backoff after 3 alerts
+	interval := time.Hour
+	base := time.Unix(0, 0)
+
+	// First three failures (times don't matter yet) should each alert.
+	for i := 0; i < 3; i++ {
+		if !tr.recordFailure("dev", warning, backoffCount, interval, base) {
+			t.Fatalf("expected alert on pre-backoff failure %d", i+1)
+		}
+	}
+
+	// Backoff is now engaged. A failure at the same instant must be suppressed.
+	if tr.recordFailure("dev", warning, backoffCount, interval, base) {
+		t.Fatal("expected backoff to suppress alert within the interval")
+	}
+	// Still inside the interval.
+	if tr.recordFailure("dev", warning, backoffCount, interval, base.Add(30*time.Minute)) {
+		t.Fatal("expected backoff to suppress alert 30m in")
+	}
+	// Past the interval - one alert allowed.
+	if !tr.recordFailure("dev", warning, backoffCount, interval, base.Add(time.Hour)) {
+		t.Fatal("expected alert once the backoff interval elapsed")
+	}
+	// Immediately after, suppressed again.
+	if tr.recordFailure("dev", warning, backoffCount, interval, base.Add(time.Hour+time.Minute)) {
+		t.Fatal("expected suppression right after a backoff alert")
+	}
+}
+
+// TestRecordSuccessResets verifies a success clears the episode so counting restarts.
+func TestRecordSuccessResets(t *testing.T) {
+	tr := newTestTracker()
+	now := time.Unix(0, 0)
+	warning := 3
+
+	// Two failures, below threshold, no alert yet.
+	tr.recordFailure("dev", warning, 5, 24*time.Hour, now)
+	tr.recordFailure("dev", warning, 5, 24*time.Hour, now)
+
+	// Success resets the counter.
+	tr.recordSuccess("dev")
+
+	// It should now take a full `warning` failures again to alert.
+	if tr.recordFailure("dev", warning, 5, 24*time.Hour, now) {
+		t.Fatal("expected no alert on first failure after reset")
+	}
+	if tr.recordFailure("dev", warning, 5, 24*time.Hour, now) {
+		t.Fatal("expected no alert on second failure after reset")
+	}
+	if !tr.recordFailure("dev", warning, 5, 24*time.Hour, now) {
+		t.Fatal("expected alert on the third failure after reset")
+	}
+}

--- a/src/configuration/config.go
+++ b/src/configuration/config.go
@@ -65,10 +65,13 @@ type DeviceConfig struct {
 	Port       int
 	Ciphers    string
 	Disabled   bool
-	// Channel to track device collection failures
-	FailChan chan bool
-	// Number of failures to trigger an alert. A value of 0 disables alerts
+	// Number of consecutive failed runs before the first alert is sent. A value of 0 disables alerts.
 	FailureWarning int
+	// FailureBackoffCount is the number of alerts sent during a single failure episode before
+	// backoff engages. Once reached, further alerts are rate limited to FailureBackoffInterval.
+	FailureBackoffCount int
+	// FailureBackoffInterval is the minimum spacing between alerts once backoff has engaged.
+	FailureBackoffInterval time.Duration
 	// SSH settings
 	SSHTimeout       time.Duration
 	SSHAuthMethod    string

--- a/src/configuration/config_file.go
+++ b/src/configuration/config_file.go
@@ -28,19 +28,17 @@ func mergeConfigFile(config *Config, filePath string) error {
 		}
 
 		deviceConfig := DeviceConfig{
-			FailureWarning:   5,
-			SSHAuthMethod:    "Password",
-			SSHTimeout:       10 * time.Second,
-			AllowInsecureSSH: true,
+			FailureWarning:         5,
+			FailureBackoffCount:    5,
+			FailureBackoffInterval: 24 * time.Hour,
+			SSHAuthMethod:          "Password",
+			SSHTimeout:             10 * time.Second,
+			AllowInsecureSSH:       true,
 		}
 
 		section.MapTo(&deviceConfig)
 		// Copy the section name into the device config for reference.
 		deviceConfig.Name = section.Name()
-		// Set up device failure channel if it isn't disabled (zero value)
-		if deviceConfig.FailureWarning > 0 {
-			deviceConfig.FailChan = make(chan bool, deviceConfig.FailureWarning)
-		}
 		config.Devices = append(config.Devices, deviceConfig)
 	}
 	return nil


### PR DESCRIPTION
## Summary

Implements the cooldown/backoff requested in #1.

Failing devices previously alerted at a fixed cadence with no cool-off. Worse, in daemon mode the failure counter never accumulated: the per-device `FailChan` lived on `DeviceConfig`, which `ReloadConfig` rebuilds every run interval (`src/core/application.go`), so the counter reset to zero every run and the alert effectively never fired. This matches the author's own note on the original `FailChan` commit: *"Not working, queue resets every run, need to make it persistent."*

## Changes

- New process-scoped `failureTracker` (`src/collectors/failure_tracker.go`), keyed by device name, that survives config reloads.
- `collectFailure` now consults the tracker instead of the reloaded `FailChan`.
- A successful collection clears the device's failure episode.
- Removed the now-unused `FailChan` field from `DeviceConfig`.

## Behavior

- `FailureWarning` (default 5, `0` disables): consecutive failed runs before the first alert. Unchanged semantics.
- Before backoff, alerts fire every `FailureWarning` failed runs.
- After `FailureBackoffCount` alerts in one episode (default 5), alerts are rate limited to one per `FailureBackoffInterval` (default 24h).

## Note

State is in-memory only; a process restart begins a fresh episode (confirmed acceptable). This fix also means alerts now actually fire in daemon mode where they previously never did - the backoff cap is what keeps that from becoming a flood.

## Testing

`go test ./...` passes on Linux (via golang:1.25 container; native Windows can't run the goterm-dependent binaries). New unit tests cover the disabled case, the initial threshold cadence, backoff rate limiting, and success reset.

fixes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)